### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ function bootstrap() {
 
     return app;
 }
+
+module.exports = bootstrap()
 ````
 
 You can install `claudia-local-api`  and run the command line Express API to test out the lambda function locally:


### PR DESCRIPTION
add module.exports into example code. Because someone confuse about the error when copy this example code and run immediately.