### PR TITLE
Feature/abbreviate logs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,15 +25,29 @@ function initServer() {
     return server;
 }
 
-function initLogger() {
+function initLogger(abbreviation) {
     const bunyan = require('bunyan');
-    return bunyan.createLogger({
+    const logger = bunyan.createLogger({
         name: packageJson.name
     });
+    // initialize maximum body logging length
+    logger.bodyAbbreviationLength = abbreviation;
+    return logger;
 }
 
 function logJson(logger, body) {
-    logger.info(JSON.stringify(body, null, 4));
+    // If the body is too long of a string, abbreviate it
+    if (body.body && body.body.length && body.body.length > logger.bodyAbbreviationLength) {
+        // Make a copy so the original body doesn't get mutated
+        const content = Object.assign({}, body);
+
+        /* eslint-disable-next-line no-param-reassign */
+        content.body = `${content.body.substr(0, logger.bodyAbbreviationLength - 3)}...`;
+
+        logger.info(JSON.stringify(content, null, 4));
+    } else {
+        logger.info(JSON.stringify(body, null, 4));
+    }
 }
 
 function logError(logger, error) {
@@ -132,6 +146,7 @@ function runCmd(bootstrapFn) {
         .version(packageJson.version)
         .option('-a --api-module <apiModule>', 'Specify claudia api path from project root')
         .option('-p --port [port]', `Specify port to use [${config.port}]`, config.port)
+        .option('--abbrev [body length]', 'Specify the maximum logged length of a response/request body [no abbreviation]', -1)
         .parse(process.argv);
 
     const apiPath = path.join(process.cwd(), program.apiModule);
@@ -141,7 +156,8 @@ function runCmd(bootstrapFn) {
     const routes = getRoutes(apiConfig.routes);
 
     const server = initServer();
-    const logger = initLogger();
+    const logger = initLogger(program.abbrev);
+
     bootstrapFn(server, logger, claudiaApp, routes, program);
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -43,6 +43,55 @@ describe('Unit tests for lib/index', function () {
             expect(spy.calledOnce).to.be.eql(true);
             expect(spy.calledWith(expectedResult)).to.be.eql(true);
         });
+
+        it('CASE 2: Should abbreviate bodies if abbrev is set', function () {
+            const logJson = localApi.__get__('logJson');
+            const spy = sinon.spy();
+            const logger = {
+                info: spy
+            };
+            logger.bodyAbbreviationLength = 11;
+
+            const body = {
+                body: 'OiPF7VcXwqydXKqIBUgucyu4I03zkqsIdAghlG8HmZiYgF6BPa'
+            };
+
+            const expected = {
+                body: 'OiPF7VcX...'
+            };
+
+            const expectedResult = JSON.stringify(expected, null, 4);
+
+            const result = logJson(logger, body);
+
+            expect(result).to.be.eq(undefined);
+            expect(spy.calledOnce).to.be.eql(true);
+            expect(spy.calledWith(expectedResult)).to.be.eql(true);
+        });
+
+        it('CASE 3: Abbreviate to nothing but ellipsis if very small', function () {
+            const logJson = localApi.__get__('logJson');
+            const spy = sinon.spy();
+            const logger = {
+                info: spy
+            };
+            logger.bodyAbbreviationLength = 0;
+            const body = {
+                body: 'OiPF7VcXwqydXKqIBUgucyu4I03zkqsIdAghlG8HmZiYgF6BPa'
+            };
+
+            const expected = {
+                body: '...'
+            };
+
+            const expectedResult = JSON.stringify(expected, null, 4);
+
+            const result = logJson(logger, body);
+
+            expect(result).to.be.eq(undefined);
+            expect(spy.calledOnce).to.be.eql(true);
+            expect(spy.calledWith(expectedResult)).to.be.eql(true);
+        });
     });
 
     context('Testing logError', function () {
@@ -544,13 +593,16 @@ describe('Unit tests for lib/index', function () {
             const runCmd = localApi.__get__('runCmd');
             const apiModule = 'test/claudia_app';
             const port = 3001;
+            const abbrev = 10;
             process.argv = [
                 'node',
                 'claudia-local-api',
                 '--api-module',
                 apiModule,
                 '--port',
-                String(port)
+                String(port),
+                '--abbrev',
+                abbrev
             ];
             const bootstrap = function (server, logger, claudiaApp, routes, options) {
                 expect(server).to.be.a('function');
@@ -558,6 +610,7 @@ describe('Unit tests for lib/index', function () {
                 expect(claudiaApp).to.be.a('object');
                 expect(options.apiModule).to.be.eql(apiModule);
                 expect(options.port).to.be.eql(String(port));
+                expect(options.abbrev).to.be.eql(abbrev);
             };
 
             const result = runCmd(bootstrap);
@@ -569,6 +622,7 @@ describe('Unit tests for lib/index', function () {
             const runCmd = localApi.__get__('runCmd');
             const apiModule = 'test/claudia_app';
             const port = 3000;
+            const abbrev = -1;
             process.argv = [
                 'node',
                 'claudia-local-api',
@@ -581,6 +635,7 @@ describe('Unit tests for lib/index', function () {
                 expect(claudiaApp).to.be.a('object');
                 expect(options.apiModule).to.be.eql(apiModule);
                 expect(options.port).to.be.eql(port);
+                expect(options.abbrev).to.be.eql(abbrev);
             };
 
             const result = runCmd(bootstrap);


### PR DESCRIPTION
## Overview

An issue that comes up when serving binary content is that the response object will get logged and print out the entire image/buffer/what have you as a utf-encoded string. This tends to A) fill up the entire terminal which makes it hard to read the rest of your logged messages, and B) notciably slow down your lambda function. This PR adds a flag (`--abbrev [abbrev amount]`) that reduces the size of `loggedObject.body` down to the specified length (with an ellipsis in the middle). Leaving the flag off causes output to be logged in full.

### Demo
What output tends to look like now with `--abbrev 200`. Normally this body string is over 10k characters long (a 256x256 .png).
```
 19:07:13.775Z  INFO claudia-local-api:
     {
         "statusCode": 200,
         "headers": {
             "Content-Type": "image/png",
             "Access-Control-Allow-Origin": "*",
             "Access-Control-Allow-Headers": "Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token",
             "Access-Control-Allow-Methods": "GET,OPTIONS",
             "Access-Control-Allow-Credentials": "true",
             "Access-Control-Max-Age": "0"
        },
         "body": "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAABG6ElEQVR4nO19B5iUVbL26zDMwAw55wwSJElGlJwkqgTFiAEDioqo[...]+BIog6lSvEDcHIQ8hIMEqIcGrqcTTJHyXe4l7UBJ+z3O00+cjYWh7sbi1YT0HDB4f8DG3dx5Umi99kAAAAASUVORK5CYII=",
         "isBase64Encoded": true
     }
```

### Notes
 * See my previous PR (#19) for context on the older commits, GitHub wouldn't let me set an unmerged branch as the base for this one.

## Testing Instructions
 * Run the example claudia project in `test/` and navigate to [`/img`](http://localhost:3000/img).
 * Output should be abbreviated rather than a gigantic UTF string.