### PR TITLE
Increase request limit / prevent caching

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,9 +17,12 @@ function initServer() {
 
     const server = express();
     server.use(bodyParser.urlencoded({
-        extended: true
+        extended: true,
+        limit: '10mb'
     }));
-    server.use(bodyParser.json());
+    server.use(bodyParser.json({
+        limit: '10mb'
+    }));
 
     return server;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,10 @@ function initServer() {
     server.use(bodyParser.json({
         limit: '10mb'
     }));
+    server.use(function(req, res, next) {
+        req.headers['if-none-match'] = 'no-match-for-this';
+        next();    
+    });
 
     return server;
 }


### PR DESCRIPTION
This PR addresses two issues of the claudia-local-api behaviour:

- Increase the request size to 10 mb (as documented here: https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html)
- Do not return 304 Not Modified (as suggested here https://stackoverflow.com/questions/14641308/how-to-totally-prevent-http-304-responses-in-connect-express-static-middleware)