### PR TITLE
Support more and variable media types, add `rawBody` per claudiajs documentation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,8 +46,10 @@ function initServer() {
     }
 
     server.use((req, res, next) => {
+        const mediaType = req.get('content-type').split(';')[0];
+
         /* hacky fix for adding rawBody */
-        switch (req.get('content-type')) {
+        switch (mediaType) {
             case 'application/json':
                 req.rawBody = JSON.stringify(req.body);
                 break;

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,18 +32,32 @@ function initServer() {
     }));
 
     for (const type of textTypes.split(',')) {
-      server.use(bodyParser.text({
-          limit,
-          type
-      }));
+        server.use(bodyParser.text({
+            limit,
+            type
+        }));
     }
 
     for (const type of binaryTypes.split(',')) {
-      server.use(bodyParser.raw({
-          limit,
-          type
-      }));
+        server.use(bodyParser.raw({
+            limit,
+            type
+        }));
     }
+
+    server.use((req, res, next) => {
+        /* hacky fix for adding rawBody */
+        switch (req.get('content-type')) {
+            case 'application/json':
+                req.rawBody = JSON.stringify(req.body);
+                break;
+            default:
+                req.rawBody = req.body;
+                break;
+        }
+
+        next();
+    });
 
     server.use(function (req, res, next) {
         req.headers['if-none-match'] = 'no-match-for-this';

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,14 +17,34 @@ function initServer() {
     const express = require('express');
     const bodyParser = require('body-parser');
 
+    const binaryTypes = process.env.BODY_PARSER_BINARY_TYPES || '*';
+    const limit = process.env.BODY_PARSER_SIZE_LIMIT || '10mb';
+    /* sane defaults */
+    const textTypes = process.env.BODY_PARSER_TEXT_TYPES || 'text/*,application/csv';
+
     const server = express();
     server.use(bodyParser.urlencoded({
         extended: true,
-        limit: '10mb'
+        limit
     }));
     server.use(bodyParser.json({
-        limit: '10mb'
+        limit
     }));
+
+    for (const type of textTypes.split(',')) {
+      server.use(bodyParser.text({
+          limit,
+          type
+      }));
+    }
+
+    for (const type of binaryTypes.split(',')) {
+      server.use(bodyParser.raw({
+          limit,
+          type
+      }));
+    }
+
     server.use(function (req, res, next) {
         req.headers['if-none-match'] = 'no-match-for-this';
         next();

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,8 @@ function initServer() {
     }
 
     server.use((req, res, next) => {
-        const mediaType = req.get('content-type').split(';')[0];
+        const contentType = req.get('content-type');
+        const mediaType = contentType ? contentType.split(';')[0] : null;
 
         /* hacky fix for adding rawBody */
         switch (mediaType) {


### PR DESCRIPTION
The goal of this PR is to get a little closer to being in-spec with the ClaudiaJS documentations surrounding the `body` and `rawBody` functionality.

Specifically, I noticed that if I try to either upload a file using a curl `POST` request or if I try to upload a string while specifying any mimetype other than `application/json` or `application/x-www-form-urlencoded` that the body is not correct. It will always have the empty object value (`{}`) and never have the contents which I attempted to submit via `POST`.

Relevant ClaudiaJS docs:
https://github.com/claudiajs/claudia-api-builder/blob/master/docs/request-object.md